### PR TITLE
Use float arithmetic to calculate weights

### DIFF
--- a/DollarP_ObjC/libs/DollarP/DollarP.m
+++ b/DollarP_ObjC/libs/DollarP/DollarP.m
@@ -108,7 +108,7 @@ int const DollarPNumPoints = 32;
             matched[index] = @YES;
         }
         
-		float weight = 1 - ((i - start + numPoints1) % numPoints1) / numPoints1;
+		float weight = 1.0f - (float)((i - start + numPoints1) % numPoints1) / numPoints1;
 		sum += weight * min;
 		i = (i + 1) % numPoints1;
         


### PR DESCRIPTION
Using integer arithmetic results in all points being weighted 1 or 0
instead of making them gradually less significant. Fix this by casting
to float.
